### PR TITLE
Allow for skipping "Handle unhelpful comments" via a label(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ nissuer comes with a default configuration, but you can override certain behavio
 
 - nissuer can hide "+1", "same issue", etc. comments on issues (partially based on [Refined GitHub](https://github.com/refined-github/refined-github/blob/c864a20b57bb433aaf3952f88d83c9fc481ae6ff/source/helpers/is-low-quality-comment.ts#L2-L3)). It won't hide comments from the repo organization members.
 - nissuer can also update the hidden comment with a note from the maintainers, explaining to the user why the comment was hidden. This is used for education purposes, so hopefully the user will be more considerate in the future.
+- nissuer can skip the "marking as off-topic and hidden" if certain a label(s) are present on the issue.
 
-| Input                      | Description                                                                        | Default Value |
-| -------------------------- | ---------------------------------------------------------------------------------- | ------------- |
-| `comment-add-explainer`    | Add an explainer to a comment that was marked as off-topic.                        | `true`        |
-| `comment-unhelpful-weight` | If an issue comment is below this rate, it will be marked as off-topic and hidden. | `0.3`         |
+| Input                             | Description                                                                                | Default Value |
+| --------------------------------- | ------------------------------------------------------------------------------------------ | ------------- |
+| `comment-add-explainer`           | Add an explainer to a comment that was marked as off-topic.                                | `true`        |
+| `comment-unhelpful-weight`        | If an issue comment is below this rate, it will be marked as off-topic and hidden.         | `0.3`         |
+| 'comment-unhelpful-ignore-labels` | Comma-separated list of labels that will prevent a comment from being marked as off-topic. |               |
 
 ### Validate reproduction URLs
 

--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ const config = {
   comments: {
     unhelpfulWeight: Number(getInput("comment_unhelpful_weight")) || 0.3,
     addExplainer: getBooleanOrUndefined("comment_add_explainer") ?? true,
+    ignoreLabels: getInput("comment_unhelpful_ignore_labels")
+      .split(",")
+      .map((l) => l.trim()),
   },
   webhook: {
     url: getInput("webhook_url"),
@@ -275,6 +278,10 @@ const updatedComment = `_Edit by maintainer bot: Comment was **automatically** m
 async function hideUnhelpfulComments() {
   const { comment, action, issue } = context.payload
   if (action !== "created" || !comment || !issue) return
+
+  // if the issue has any of labels given from comment-unhelpful-ignore-labels, then skip hiding the comment
+  const issueLabels = issue.labels.map((label) => label.name)
+  if (issueLabels.some((label) => config.comments.ignoreLabels.includes(label))) return
 
   const {
     node_id: subjectId,


### PR DESCRIPTION
## What?

Add a feature that allows us to skip the **Handle unhelpful comments** step if a certain label(s) exist.

## Why?

Gives more granularity to the **Handle unhelpful comments** step.

- https://github.com/vercel/next.js/pull/75451
