### PR TITLE
docs: fix syntax highlighting in YAML code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ nissuer comes with a default configuration, but you can override certain behavio
 
 Here is a minimal setup of nissuer. Add a workflow (eg. `.github/workflows/nissuer.yml`):
 
-```.github/workflows/nissuer.yml
+```yaml
 name: Triage via nissuer
 
 on:


### PR DESCRIPTION
## Summary

The syntax highlighting in the YAML code block in the README was incorrect

## Details

- it should show have the language at the top of the code block, not the file name
  - replace `.github/workflows/nissuer.yml` with `yaml`
  
## Verification

Can see the [rendered markdown in this PR's commit](https://github.com/balazsorban44/nissuer/blob/24aaa44947a3f5d1387e418ade22cc65403cc3ac/README.md#usage).

<details> <summary>Here are also some before/after screenshots: </summary>

Before:
![before -Screenshot 2025-04-17 at 9 43 15 PM](https://github.com/user-attachments/assets/8a162b1c-b5e2-42bb-b7c2-26262dbdc795)


After:
![after - Screenshot 2025-04-17 at 9 44 55 PM](https://github.com/user-attachments/assets/be7023b8-c80e-4741-8191-34a12628d49f)

</details>